### PR TITLE
:sparkles: Allow skipping Sarif Upload

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,15 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 # [Optional] Uncomment the next lines to use go get to install anything else you need
 USER vscode
+
+# Installing govulncheck && tools used by VSCode Go Extension+
 RUN go install golang.org/x/vuln/cmd/govulncheck@latest
+RUN go install github.com/cweill/gotests/gotests@latest
+RUN go install github.com/fatih/gomodifytags@latest
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+RUN go install golang.org/x/tools/gopls@latest
+
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Package",
+            "name": "Launch Action",
             "type": "go",
             "request": "launch",
             "mode": "auto",

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ For a full list of currently known limitations please head over to [here](https:
 
 ## Usage
 
-### Example Workflow
+### Example Workflows
 
-The below example configuration uses go version 1.18 and the latest version of govulncheck. It will scan `./...`. Additionally it's configured to fail on finding a vulnerability.
+<details>
+  <summary>
+  This configuration uses a different version of go (1.18) scans ./... and will fail if at least one vulnerability was found. Also it explicitly sets the github-token.
+  </summary>
 
 ```yaml
 name: My Workflow
@@ -39,8 +42,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-vuln: true
 ```
+</details>
 
-The below example configuration uses most of the default values, but will fail on any found vulnerability and also skip the upload. Instead it will upload the sarif report as build artifact using another action.
+<details>
+  <summary>
+  This configuration uses most of the default values, which are specified below. However it skips the upload to Github and instead uses the upload-artifact-action
+  to upload the result directly as build artifact.
+  </summary>
 
 ```yaml
 name: My Workflow
@@ -53,7 +61,6 @@ jobs:
       - name: Running govulncheck
         uses: Templum/govulncheck-action@<version>
         with:
-          fail-on-vuln: true
           skip-upload: true
       - name: Upload Sarif Report
         uses: actions/upload-artifact@v3
@@ -61,6 +68,7 @@ jobs:
           name: sarif-report
           path: govulncheck-report.sarif
 ```
+</details>
 
 ### Inputs
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ For a full list of currently known limitations please head over to [here](https:
 
 ### Example Workflow
 
+The below example configuration uses go version 1.18 and the latest version of govulncheck. It will scan `./...`. Additionally it's configured to fail on finding a vulnerability.
+
 ```yaml
 name: My Workflow
 on: [push, pull_request]
@@ -38,6 +40,28 @@ jobs:
           fail-on-vuln: true
 ```
 
+The below example configuration uses most of the default values, but will fail on any found vulnerability and also skip the upload. Instead it will upload the sarif report as build artifact using another action.
+
+```yaml
+name: My Workflow
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Running govulncheck
+        uses: Templum/govulncheck-action@<version>
+        with:
+          fail-on-vuln: true
+          skip-upload: true
+      - name: Upload Sarif Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: sarif-report
+          path: govulncheck-report.sarif
+```
+
 ### Inputs
 
 | Input                            | Description                                                                                                    |
@@ -47,6 +71,7 @@ jobs:
 | `package` _(optional)_           | The package you want to scan, by default will be `./...`                                                       |
 | `github-token` _(optional)_      | Github Token to upload sarif report. **Needs** `write` permissions for `security_events`                       |
 | `fail-on-vuln` _(optional)_      | This allows you to specify if the action should fail on encountering any vulnerability, by default it will not |
+| `skip-upload` _(optional)_       | This flag allows you to skip the sarif upload, it will be instead written to disk as `govulncheck-report.sarif`|
 
 > :warning: Please be aware that go-version should be a valid tag name for the [golang dockerhub image](https://hub.docker.com/_/golang/tags).
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "This allows you to specify if the action should fail on encountering any vulnerability, by default it will not"
     default: false
     required: false
+  skip-upload:
+    description: "This flag allows you to skip the sarif upload, it will be instead written to disk"
+    default: false
+    required: false
 
 runs:
   using: "composite"
@@ -30,7 +34,7 @@ runs:
       run: docker build --build-arg GOLANG_VERSION=${{ inputs.go-version }} --build-arg VULNCHECK_VERSION=${{ inputs.vulncheck-version }} -q -f $GITHUB_ACTION_PATH/Dockerfile -t templum/govulncheck-action:local $GITHUB_ACTION_PATH
       shell: bash
     - id: run
-      run: docker run --rm -v $(pwd):/github/workspace --workdir /github/workspace -e GITHUB_TOKEN=${{ inputs.github-token }} -e STRICT=${{ inputs.fail-on-vuln }} -e PACKAGE=${{ inputs.package }} -e GITHUB_REPOSITORY=${{ github.repository }} -e GITHUB_REF=${{ github.ref }} -e GITHUB_SHA=${{ github.sha }} templum/govulncheck-action:local
+      run: docker run --rm -v $(pwd):/github/workspace --workdir /github/workspace -e GITHUB_TOKEN=${{ inputs.github-token }} -e STRICT=${{ inputs.fail-on-vuln }} -e PACKAGE=${{ inputs.package }} -e SKIP_UPLOAD=${{ inputs.skip-upload }} -e GITHUB_REPOSITORY=${{ github.repository }} -e GITHUB_REF=${{ github.ref }} -e GITHUB_SHA=${{ github.sha }} templum/govulncheck-action:local
       shell: bash
 
 branding:


### PR DESCRIPTION
This PR implements feature request #10 by offering a new input called `skip-upload`. By default, this will be `false`, but it can be set to `true`. 

If set to true it will skip the upload and instead write to a file, which then can be consumed or shared with other actions. To highlight this I added a new Example Workflow that uses the `upload-artifact`-action to upload the file. 