### PR TITLE
:sparkles: :bug: Reading Go Runtime Details from GOENV

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"os"
-	"runtime"
 
+	"github.com/Templum/govulncheck-action/pkg/action"
 	"github.com/Templum/govulncheck-action/pkg/github"
 	"github.com/Templum/govulncheck-action/pkg/sarif"
 	"github.com/Templum/govulncheck-action/pkg/vulncheck"
@@ -33,10 +33,16 @@ func main() {
 		logger.Debug().Msg("Enabled Local Development mode, scanner will return static result based on found.json")
 	}
 
+	info, err := action.ReadRuntimeInfoFromEnv()
+
+	if err != nil {
+		logger.Warn().Err(err).Msg("Could not determine go runtime information")
+	}
+
 	logger.Info().
-		Str("Go-Version", runtime.Version()).
-		Str("Go-Os", runtime.GOOS).
-		Str("Go-Arch", runtime.GOARCH).
+		Str("Go-Version", info.Version).
+		Str("Go-Os", info.Os).
+		Str("Go-Arch", info.Arch).
 		Msg("GoEnvironment Details:")
 
 	logger.Debug().

--- a/main.go
+++ b/main.go
@@ -33,11 +33,7 @@ func main() {
 		logger.Debug().Msg("Enabled Local Development mode, scanner will return static result based on found.json")
 	}
 
-	info, err := action.ReadRuntimeInfoFromEnv()
-
-	if err != nil {
-		logger.Warn().Err(err).Msg("Could not determine go runtime information")
-	}
+	info := action.ReadRuntimeInfoFromEnv()
 
 	logger.Info().
 		Str("Go-Version", info.Version).

--- a/pkg/action/env.go
+++ b/pkg/action/env.go
@@ -1,0 +1,46 @@
+package action
+
+import (
+	"os/exec"
+	"strings"
+)
+
+type RuntimeInfos struct {
+	Version string
+	Os      string
+	Arch    string
+}
+
+func ReadRuntimeInfoFromEnv() (*RuntimeInfos, error) {
+	cmd := exec.Command("go", "env")
+	out, err := cmd.Output()
+
+	if err != nil {
+		return nil, err
+	}
+
+	info := RuntimeInfos{}
+
+	envs := strings.Split(string(out), "\n")
+
+	for _, env := range envs {
+
+		if strings.Contains(env, "GOARCH") {
+			keyVal := strings.SplitAfter(env, "=")
+			info.Arch = strings.Trim(keyVal[1], "\"")
+		}
+
+		if strings.Contains(env, "GOVERSION") {
+			keyVal := strings.SplitAfter(env, "=")
+			info.Version = strings.Trim(keyVal[1], "\"")
+		}
+
+		if strings.Contains(env, "GOOS") {
+			keyVal := strings.SplitAfter(env, "=")
+			info.Os = strings.Trim(keyVal[1], "\"")
+		}
+
+	}
+
+	return &info, nil
+}

--- a/pkg/action/env.go
+++ b/pkg/action/env.go
@@ -11,15 +11,12 @@ type RuntimeInfos struct {
 	Arch    string
 }
 
-func ReadRuntimeInfoFromEnv() (*RuntimeInfos, error) {
+// ReadRuntimeInfoFromEnv using go env this ensures the real information are used and no compile time versions
+func ReadRuntimeInfoFromEnv() *RuntimeInfos {
 	cmd := exec.Command("go", "env")
-	out, err := cmd.Output()
+	out, _ := cmd.Output()
 
-	if err != nil {
-		return nil, err
-	}
-
-	info := RuntimeInfos{}
+	info := RuntimeInfos{Version: "Unknown", Os: "Unknown", Arch: "Unknown"}
 
 	envs := strings.Split(string(out), "\n")
 
@@ -42,5 +39,5 @@ func ReadRuntimeInfoFromEnv() (*RuntimeInfos, error) {
 
 	}
 
-	return &info, nil
+	return &info
 }

--- a/pkg/action/env_test.go
+++ b/pkg/action/env_test.go
@@ -1,0 +1,20 @@
+package action
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadRuntimeInfoFromEnv(t *testing.T) {
+	t.Run("should go runtime information from go env", func(t *testing.T) {
+		info := ReadRuntimeInfoFromEnv()
+
+		assert.NotNil(t, info, "should not return nil")
+
+		assert.Equal(t, runtime.Version(), info.Version)
+		assert.Equal(t, runtime.GOOS, info.Os)
+		assert.Equal(t, runtime.GOARCH, info.Arch)
+	})
+}


### PR DESCRIPTION
Within my Dockerfile I use the builder pattern, ensuring the action itself is compiled with a golang version I control. The version chosen by the user of the action will be installed in the runtime part of the container, into which I also install the vulncheck cli. Meaning the CLI is run in the correct env, just the output is incorrect. In fix/16 I switched to reading the go env. This contains the actual runtime information that is relevant to govulncheck.