### PR TITLE
:construction_worker: Implement Integration Test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,14 @@ jobs:
         env:
           GH_PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           GOPRIVATE: "github.com/Templum/private-lib"
+      - name: Ensure at least 8 Vulnerabilities are discovered
+        run: |
+          rules=$(cat govulncheck-report.sarif | jq '.runs[0].tool.driver.rules | length')
+          occurrences=$(cat govulncheck-report.sarif | jq '.runs[0].results | length')
+          if [[ $rules -ge 8 ]]; then echo "Found expected number of rules"; else echo "Found unexpected number of rules $rules expected 8"; exit 1; fi
+          if [[ $occurrences -ge 8 ]]; then echo "Found expected number of call sites"; else echo "Found unexpected number of call sites ($occurrences expected 8)"; exit 1; fi
       - name: Upload Report
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
           name: sarif-report

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
           occurrences=$(cat govulncheck-report.sarif | jq '.runs[0].results | length')
           if [[ $rules -ge 8 ]]; then echo "Found expected number of rules"; else echo "Found unexpected number of rules $rules expected 8"; exit 1; fi
           if [[ $occurrences -ge 8 ]]; then echo "Found expected number of call sites"; else echo "Found unexpected number of call sites ($occurrences expected 8)"; exit 1; fi
-      - name: Upload Report
+      - name: Upload Report if Test failed
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feature/integration-test # Temporary for testing
     tags:
       - v*
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,10 +9,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - name: Debug
-        run: pwd && ls
-        shell: bash
-      - name: Integration Test
-        id: integration-test
+      - name: Checkout playground repository
+        uses: actions/checkout@main
+        with:
+          repository: Templum/playground
+      - name: Run Action against known repository and skip upload to compare generated file
         uses: Templum/govulncheck-action@main
+        with:
+          skip-upload: true
+          go-version: 1.19
+        env:
+          GH_PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GOPRIVATE: "github.com/Templum/private-lib"
+      - name: Upload Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: raw-report
+          path: raw-report.json

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Upload Report
         uses: actions/upload-artifact@v3
         with:
-          name: raw-report
-          path: raw-report.json
+          name: sarif-report
+          path: govulncheck-report.sarif

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feature/integration-test # Temporary for testing
     tags:
       - v*
   schedule:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,8 @@ on:
       - feature/integration-test # Temporary for testing
     tags:
       - v*
+  schedule:
+    - cron: '0 22 */3 * *'
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It is leveraging the playground repository to perform an integration test. As that repository has a fixed set of known vulnerabilities, it allows for ensuring no regression is faced by the action. 

As playground uses a private lib #21 needs to be merged first.
