### PR TITLE
:pushpin: Pinned default's to latest govulncheck (1.0) and golang 1.20.6

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 RUN go install golang.org/x/tools/gopls@latest
 
 # Installing govulncheck
-ARG VULNCHECK_VERSION="v0.1.0"
+ARG VULNCHECK_VERSION="v1.0.0"
 RUN go install golang.org/x/vuln/cmd/govulncheck@$VULNCHECK_VERSION
 
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
             "VARIANT": "1.20-bullseye",
             // Options
             "NODE_VERSION": "none",
-            "VULNCHECK_VERSION": "v0.1.0"
+            "VULNCHECK_VERSION": "v1.0.0"
         }
     },
     "runArgs": [
@@ -22,18 +22,19 @@
     "customizations": {
         "vscode": {
             "settings": {
-                "go.gocodeAutoBuild": false,
+                "go.useLanguageServer": true,
                 "files.autoSave": "afterDelay",
                 "editor.formatOnPaste": true,
                 "editor.formatOnSave": true,
+                "gopls": {
+                    "ui.completion.usePlaceholders": true
+                },
                 "go.gopath": "/go",
                 "go.goroot": "/usr/local/go",
                 "go.toolsGopath": "/go/bin",
-                "go.buildOnSave": "workspace",
                 "go.lintOnSave": "package",
                 "go.vetOnSave": "package",
                 "go.coverOnSave": false,
-                "go.useCodeSnippetsOnFunctionSuggest": false,
                 "go.lintTool": "golangci-lint",
                 "go.formatTool": "goimports",
                 "[go]": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.19
+ARG GOLANG_VERSION=1.20
 # This golang version is for the builder only
 FROM golang:1.20 as builder
 
@@ -13,7 +13,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-w -s" -v -o action .
 # This golang version determines in which golang environment the customer code is checked
 FROM golang:$GOLANG_VERSION
-ARG VULNCHECK_VERSION=v0.1.0 
+ARG VULNCHECK_VERSION=v1.0.0 
 RUN go install golang.org/x/vuln/cmd/govulncheck@$VULNCHECK_VERSION
 
 # This allows private repositories hosted on Github

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,13 @@ inputs:
     required: false
     default: "./..."
   go-version:
-    description: "Can be any Tag for the golang docker image, but should ideally match your runtime go version. By default 1.19 is assumed"
+    description: "Can be any Tag for the golang docker image, but should ideally match your runtime go version. By default 1.20.6 is assumed"
     required: false
-    default: "1.19"
+    default: "1.20.6"
   vulncheck-version:
     description: "Version of govulncheck that should be used, by default v0.0.0-20230331150530-a42f9910daf3"
     required: false
-    default: "v0.0.0-20230331150530-a42f9910daf3"
+    default: "v1.0.0"
   github-token:
     description: "Github App token to upload sarif report. Needs write permissions for security_events. By default it will use 'github.token' value"
     default: ${{ github.token }}


### PR DESCRIPTION
It's important to highlight that GitHub Actions appear to have a parsing bug. If you select `1.20` it will be provided to the Action as `1.2`. Therefore I choose to leverage `1.20.6` to avoid this bug.