### PR TITLE
Maintain major/minor tags

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     tags:
-      - v*
+      - v[0-9]+.[0-9]+.[0-9]+
   schedule:
     - cron: '0 22 */3 * *'
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Process
 on:
   push: # Only trigger for tags with format v****
     tags:
-      - 'v*'
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   build:
@@ -18,3 +18,5 @@ jobs:
         with:
           generate_release_notes: true
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update Tags
+        uses: vweevers/additional-tags-action@v2


### PR DESCRIPTION
Hello @Templum,
This change will automatically maintain the `vX` and `vX.X` tags on every release. It should allow users to lock to a major version and update the workflows less frequently:
```yml
name: My Workflow
on: [push, pull_request]
jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: Templum/govulncheck-action@v1
```

In addition to that, the release flow will force a semantic version tag and not any tag that start with `v` letter.