### PR TITLE
:sparkles: Better & Improved error propagation from govulncheck thrown errors.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.231.6/containers/go/.devcontainer/base.Dockerfile
 
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT="1.21-bullseye"
+ARG VARIANT="1.22-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,10 +8,10 @@
             // Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
             // Append -bullseye or -buster to pin to an OS version.
             // Use -bullseye variants on local arm64/Apple Silicon.
-            "VARIANT": "1.21-bullseye",
+            "VARIANT": "1.22-bullseye",
             // Options
             "NODE_VERSION": "none",
-            "VULNCHECK_VERSION": "v1.0.0"
+            "VULNCHECK_VERSION": "v1.1.0"
         }
     },
     "runArgs": [
@@ -39,7 +39,7 @@
                 "go.formatTool": "goimports",
                 "[go]": {
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": true
+                        "source.organizeImports": "always"
                     }
                 },
                 "[go.mod]": {


### PR DESCRIPTION
This closes #79 by properly propagating any error thrown by the govulncheck binary. Also, I started introducing a set of "known" issues that ideally help users understand the underlying error more easily. 